### PR TITLE
Remove npm install from Travis CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ node_js:
   - "8"
 
 script:
-  - npm install
   - npm run lint


### PR DESCRIPTION
Travis runs npm install automatically before running the tests